### PR TITLE
fix: Add redirect status check to onRequestPausedEvent

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,10 @@ export class RequestInterceptionManager {
       if (resourceType && resourceType !== event.resourceType) continue
       if (urlPattern && !urlPatternRegExp.test(request.url)) continue
 
-      if (!responseStatusCode) {
+      if (
+        !responseStatusCode ||
+        (responseStatusCode >= 300 && responseStatusCode < 400)
+      ) {
         // handling a request
         const { delay, ...modification } =
           (await modifyRequest?.({ event })) ?? {}


### PR DESCRIPTION
Could you review this pull request that addresses the following issue?

When redirected to a new page, the following error occurs:
`ProtocolError: Protocol error (Fetch.getResponseBody): can only retrieve body after receiving headers.`

Related issue: https://github.com/niieani/puppeteer-intercept-and-modify-requests/issues/10