### PR TITLE
Remove deprecated page.target from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import { RequestInterceptionManager } from 'puppeteer-intercept-and-modify-reque
 // assuming 'page' is your Puppeteer page object
 const client = await page.createCDPSession()
 // note: if you want to intercept requests on ALL tabs, instead use:
-// const client = await browser.createCDPSession()
+// const client = await browser.target().createCDPSession()
 
 const interceptManager = new RequestInterceptionManager(client)
 
@@ -294,7 +294,7 @@ When creating the `RequestInterceptionManager` instance, you can pass in the `cl
 
 ```ts
 // intercept requests on ALL tabs, instead use:
-const client = await browser.createCDPSession()
+const client = await browser.target().createCDPSession()
 const interceptManager = new RequestInterceptionManager(client)
 
 // ...

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ To modify intercepted requests:
 import { RequestInterceptionManager } from 'puppeteer-intercept-and-modify-requests'
 
 // assuming 'page' is your Puppeteer page object
-const client = await page.target().createCDPSession()
+const client = await page.createCDPSession()
 // note: if you want to intercept requests on ALL tabs, instead use:
-// const client = await browser.target().createCDPSession()
+// const client = await browser.createCDPSession()
 
 const interceptManager = new RequestInterceptionManager(client)
 
@@ -118,7 +118,7 @@ async function main() {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 
-  const client = await page.target().createCDPSession()
+  const client = await page.createCDPSession()
   const requestInterceptionManager = new RequestInterceptionManager(client)
 
   const interceptionConfig: Interception = {
@@ -185,7 +185,7 @@ async function main() {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 
-  const client = await page.target().createCDPSession()
+  const client = await page.createCDPSession()
   const requestInterceptionManager = new RequestInterceptionManager(client)
 
   const interceptionConfig: Interception = {
@@ -223,7 +223,7 @@ async function main() {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 
-  const client = await page.target().createCDPSession()
+  const client = await page.createCDPSession()
   const requestInterceptionManager = new RequestInterceptionManager(client, {
     onError: (error) => {
       console.error('Request interception error:', error)
@@ -265,7 +265,7 @@ async function main() {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 
-  const client = await page.target().createCDPSession()
+  const client = await page.createCDPSession()
   const requestInterceptionManager = new RequestInterceptionManager(client)
 
   const interceptionConfig: Interception = {
@@ -294,7 +294,7 @@ When creating the `RequestInterceptionManager` instance, you can pass in the `cl
 
 ```ts
 // intercept requests on ALL tabs, instead use:
-const client = await browser.target().createCDPSession()
+const client = await browser.createCDPSession()
 const interceptManager = new RequestInterceptionManager(client)
 
 // ...
@@ -315,7 +315,7 @@ async function main() {
   const browser = await puppeteer.launch()
   const page = await browser.newPage()
 
-  const client = await page.target().createCDPSession()
+  const client = await page.createCDPSession()
   const requestInterceptionManager = new RequestInterceptionManager(client)
 
   const interceptionConfig: Interception = {


### PR DESCRIPTION
Page.target is deprecated, Page.createCDPSession should be used directly.