### PR TITLE
fix: use `puppeteer` package types instead of `puppeteer-core`

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,7 @@
   "devDependencies": {
     "@niieani/scaffold": "^1.7.11",
     "get-port": "^5.0.0",
-    "puppeteer": "^21.5.0",
-    "puppeteer-core": "^21.5.0"
+    "puppeteer": "^21.5.0"
   },
   "packageManager": "yarn@3.5.0",
   "publishConfig": {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -2,18 +2,15 @@
 import * as http from 'http'
 import getPort from 'get-port'
 import type { Server } from 'http'
-import * as _puppeteer from 'puppeteer'
-import type * as puppeteerType from 'puppeteer-core'
+import * as puppeteer from 'puppeteer'
 import { RequestInterceptionManager } from './main'
-
-const puppeteer = _puppeteer as unknown as typeof puppeteerType
 
 let server: Server
 let port = 3_000
-let browser: puppeteerType.Browser
-let page: puppeteerType.Page
-let client: puppeteerType.CDPSession
-let browserClient: puppeteerType.CDPSession
+let browser: puppeteer.Browser
+let page: puppeteer.Page
+let client: puppeteer.CDPSession
+let browserClient: puppeteer.CDPSession
 let manager: RequestInterceptionManager
 
 const host = 'localhost'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-continue,no-await-in-loop,node/no-unpublished-import */
 import { promisify } from 'util'
-import type { CDPSession, Protocol } from 'puppeteer-core'
+import type { CDPSession, Protocol } from 'puppeteer'
 // eslint-disable-next-line import/no-unresolved
 import { getUrlPatternRegExp } from './urlPattern.js'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12102,7 +12102,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"puppeteer-core@npm:21.5.0, puppeteer-core@npm:^21.5.0":
+"puppeteer-core@npm:21.5.0":
   version: 21.5.0
   resolution: "puppeteer-core@npm:21.5.0"
   dependencies:
@@ -12124,7 +12124,6 @@ __metadata:
     escape-string-regexp: "npm:^4.0.0"
     get-port: "npm:^5.0.0"
     puppeteer: "npm:^21.5.0"
-    puppeteer-core: "npm:^21.5.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
`puppeteer` exports types so there's no need to use `puppeteer-core` for types. In fact, this creates a type mismatch for the consumer:

![image](https://github.com/user-attachments/assets/ff33387e-bf10-40c4-84e7-375b64a63cae)

Since `client` is of type `puppeteer.CDPSession` and `RequestInterceptionManager` expects `puppeteer-core.CDPSession`, and they are for some reason different.